### PR TITLE
CHANGE(elasticsearch): move variables from `vars` to `default`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,3 @@
-# roles/elasticsearch/defaults/main.yml
 ---
 openio_elasticsearch_namespace: "{{ namespace | default('OPENIO') }}"
 
@@ -66,4 +65,18 @@ openio_elasticseach_filebeat_lifecycle:
         min_age: 30d
         actions:
           delete: {}
+
+openio_elasticsearch_servicename: "elasticsearch-{{ openio_elasticsearch_serviceid }}"
+openio_elasticsearch_log_dir:
+  "/var/log/oio/sds/{{ openio_elasticsearch_namespace }}/{{ openio_elasticsearch_servicename }}"
+openio_elasticsearch_sysconfig_dir:
+  "/etc/oio/sds/{{ openio_elasticsearch_namespace }}/{{ openio_elasticsearch_servicename }}"
+openio_elasticsearch_pid_directory: "/run/oio/sds/{{ openio_elasticsearch_namespace }}"
+openio_elasticsearch_definition_file: >
+  "{{ openio_elasticsearch_sysconfig_dir }}/
+  {{ openio_elasticsearch_servicename }}/{{ openio_elasticsearch_servicename }}.conf"
+openio_elasticsearch_classpath:
+  - "{{ openio_elasticsearch_sysconfig_dir }}/{{ openio_elasticsearch_servicename }}"
+  - /usr/share/elasticsearch/lib/*
+openio_elasticsearch_url: "http://{{ openio_elasticsearch_bind_address }}:{{ openio_elasticsearch_bind_port }}"
 ...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,18 +1,3 @@
 ---
-openio_elasticsearch_servicename: "elasticsearch-{{ openio_elasticsearch_serviceid }}"
-openio_elasticsearch_log_dir:
-  "/var/log/oio/sds/{{ openio_elasticsearch_namespace }}/{{ openio_elasticsearch_servicename }}"
-openio_elasticsearch_sysconfig_dir:
-  "/etc/oio/sds/{{ openio_elasticsearch_namespace }}/{{ openio_elasticsearch_servicename }}"
-openio_elasticsearch_pid_directory: "/run/oio/sds/{{ openio_elasticsearch_namespace }}"
-
 openio_elasticsearch_version: "7.x"
-
-openio_elasticsearch_definition_file: >
-  "{{ openio_elasticsearch_sysconfig_dir }}/
-  {{ openio_elasticsearch_servicename }}/{{ openio_elasticsearch_servicename }}.conf"
-openio_elasticsearch_classpath:
-  - "{{ openio_elasticsearch_sysconfig_dir }}/{{ openio_elasticsearch_servicename }}"
-  - /usr/share/elasticsearch/lib/*
-openio_elasticsearch_url: "http://{{ openio_elasticsearch_bind_address }}:{{ openio_elasticsearch_bind_port }}"
 ...


### PR DESCRIPTION
 ##### SUMMARY
in `vars` should only remain variables that must be fixed.
All the others must be set in `defaults` (almost all variables).

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION