### PR TITLE
CHANGE(elasticsearch): add `oio_message` in the index

### DIFF
--- a/files/filebeat_index.json
+++ b/files/filebeat_index.json
@@ -22,6 +22,10 @@
         "ignore_above": 16,
         "type": "keyword"
       },
+      "oio_message": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
       "oio_method": {
         "ignore_above": 16,
         "type": "keyword"


### PR DESCRIPTION
 ##### SUMMARY

`oio_message` is used for error logs and was not indexed

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION

(cherry picked from commit a03aef0c80a301a85420f6f8b903626beac79e10)