### PR TITLE
BUGFIX/MINOR(elasticsearch): fix `openio_bind_mgmt_address` typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An Ansible role for install elasticsearch. Specifically, the responsibilities of
 | :---       | :---    | :---             |
 | `openio_elasticsearch_namespace` | `"{{ namespace \| d('OPENIO') }}"` | OpenIO Namespace |
 | `openio_elasticsearch_maintenance_mode` | `"{{ openio_maintenance_mode \| d(false) }}"` | Maintenance mode |
-| `openio_elasticsearch_bind_address` | `"{{ openio_mgmt_bind_address \| d(ansible_default_ipv4.address) }}"` | Binding IP address |
+| `openio_elasticsearch_bind_address` | `"{{ openio_bind_mgmt_address \| d(ansible_default_ipv4.address) }}"` | Binding IP address |
 | `openio_elasticsearch_bind_port` | `6904` | HTTP Binding port |
 | `openio_elasticsearch_transport_port` | `6905` | TCP Binding port |
 | `openio_elasticsearch_url` | `"http://{{ openio_elasticsearch_bind_address }}:{{ openio_elasticsearch_bind_port}}"` | URL to access elasticsearch |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 openio_elasticsearch_namespace: "{{ namespace | d('OPENIO') }}"
 openio_elasticsearch_maintenance_mode: "{{ openio_maintenance_mode | d(false) }}"
 
-openio_elasticsearch_bind_address: "{{ openio_mgmt_bind_address | d(ansible_default_ipv4.address) }}"
+openio_elasticsearch_bind_address: "{{ openio_bind_mgmt_address | d(ansible_default_ipv4.address) }}"
 openio_elasticsearch_bind_port: 6904
 openio_elasticsearch_transport_port: 6905
 


### PR DESCRIPTION
 ##### SUMMARY
`openio_bind_mgmt_address` instead of `openio_mgmt_bind_address`

 ##### IMPACT
#Describe the impact of the change (N/A for no impact)
N/A

 ##### ADDITIONAL INFORMATION