### PR TITLE
BUGFIX/MINOR(elasticsearch): ignore local addr when not set

### DIFF
--- a/files/pipelines/oio-filebeat.json
+++ b/files/pipelines/oio-filebeat.json
@@ -3,6 +3,12 @@
   "processors" : [
     {
       "remove" : {
+        "if": "ctx.oio_local_addr== '-'",
+        "field": "oio_local_addr"
+      }
+    },
+    {
+      "remove" : {
         "if": "ctx.oio_remote_addr== '-'",
         "field": "oio_remote_addr"
       }


### PR DESCRIPTION
 ##### SUMMARY

`oio_local_addr` can be set to `-` and it raised an error.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION